### PR TITLE
delete link to maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,13 +316,6 @@
             <div class="sticky">
               <h2>Hand drauf!</h2>
               <p>Reserviere etwas von unserem Kaffee und werde Kompliz*in der Gemeinnützigkeit.</p>
-              
-              <!-- NICHT MEHR AKTUELL
-              <p>Wenn Du Dich erst noch geschmacklich überzeugen willst, dann komm in der <a href="https://trafo-ms.de">Trafostation</a> in Münster vorbei und koste unseren Kaffee.</p><br>
-              <a href="https://www.trafo-ms.de"><img src="images/svg/trafo.png" alt="Trafo" style="width:100%;" id="svg" target="_blank"></a>
-              <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2458.25384039007!2d7.621306716112531!3d51.96579687971307!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47b9bac1fe06b73f%3A0x4cc5290ac54a4644!2sTrafostation%20M%C3%BCnster!5e0!3m2!1sde!2sde!4v1570210647901!5m2!1sde!2sde" width=100% height="450" frameborder="0" style="border:0;" allowfullscreen="" id="svg"></iframe>
-              -->
-              
             </div>
           </header>
             <div class="survey-content">


### PR DESCRIPTION
Unverständliches Problem:
In meiner lokalen Kopie/Clone klappt alles, aber sobald die website mit den Änderungen online war, wurde statt des Formulars die Karte mit der Trafo eingebettet. Unverständlich für mich, weil der Link nur al Kommentar im Code stand!? Hab jetzt mal den Kommentar gelöscht, vielleicht klappt es?